### PR TITLE
Fix header typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Outline the required components and tools that a user might need to have on thei
 
 Explain how to prepare the sample once the user clones or downloads the repository. The section should outline every step necessary to install dependencies and set up any settings (for example, API keys and output folders).
 
-## Runnning the sample
+## Running the sample
 
 Outline step-by-step instructions to execute the sample and see its output. Include steps for executing the sample from the IDE, starting specific services in the Azure portal or anything related to the overall launch of the code.
 


### PR DESCRIPTION
This came from the original repo template. I submitted a fix PR there (pending merge), but several repos already contained the typo.