### PR TITLE
Upgrade to dotnet 3.1 to support current Azure Cloudshell

### DIFF
--- a/Controllers/PatientRecordController.cs
+++ b/Controllers/PatientRecordController.cs
@@ -9,8 +9,6 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using Azure.Storage;
 
-
-
 namespace patientrecords.Controllers
 {
     [ApiController]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the supporting code and deployment resources for the [C
 
 ## Prerequisites
 
-The sample is built on .NET Core 2.2, Razor, Bootstrap, and jQuery.
+The sample is built on .NET Core 3.1, Razor, Bootstrap, and jQuery.
 
 ## Setup
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,12 +19,13 @@ namespace patientrecords
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services
-                .AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddRazorPages();
+            services.AddMvc();
+            services.AddSingleton<IConfiguration>(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -35,9 +37,16 @@ namespace patientrecords
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
-
             app.UseStaticFiles();
-            app.UseMvc();
+
+            app.UseRouting(); 
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => {
+                endpoints.MapRazorPages();
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -41,8 +41,6 @@ namespace patientrecords
 
             app.UseRouting(); 
 
-            app.UseAuthorization();
-
             app.UseEndpoints(endpoints => {
                 endpoints.MapRazorPages();
                 endpoints.MapControllers();

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "2.2.401"
+    "version": "3.1.401",
+    "rollForward": "latestMinor"
   }
 }

--- a/patient-records.csproj
+++ b/patient-records.csproj
@@ -1,14 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>patientrecords</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.1.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.4.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
+  <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates to allow a fix for: #4 
* Update to global.json to 3.1.401 currently on Azure Cloudshell
* Added rollForward in global.json to latest minor for future compatibility
* Updated csproj to target netcoreapp3.1
* Updated csproj to remove unrequired package references and added updated package references for 3.1
* Updated startup to roll back initial changes and be compatible for 3.1