### PR TITLE
Address production bug

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -17,7 +17,7 @@
 </div>
 
 <script>
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         $('#btn-all').on('click', function () {
             $.get('api/PatientRecords', function (data) {
                 $('#result').empty();


### PR DESCRIPTION
jQuery is only available for use in inline scripts in development mode.

This happens because `_Layout.cshtml` includes the unminified version of jQuery in the document `<head />` only for the development environment:

https://github.com/MicrosoftDocs/mslearn-control-access-to-azure-storage-with-sas/blob/d26dc0090c3f6b3378918f9a2f3346e303a167ba/Pages/Shared/_Layout.cshtml#L7

```html
    <environment include="Development">
        <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.css" />
        <script src="lib/jquery/dist/jquery.js"></script>
        <script src="lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
    </environment>
```

In all other environments, jQuery is included in minified form before the closing body tag:

https://github.com/MicrosoftDocs/mslearn-control-access-to-azure-storage-with-sas/blob/d26dc0090c3f6b3378918f9a2f3346e303a167ba/Pages/Shared/_Layout.cshtml#L55

```html
    <environment exclude="Development">
        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
                asp-fallback-src="lib/jquery/dist/jquery.min.js"
                asp-fallback-test="window.jQuery"
                crossorigin="anonymous"
                integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=">
        </script>
        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"
                asp-fallback-src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"
                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
                crossorigin="anonymous"
                integrity="sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o">
        </script>
    </environment>
```

If merged, this commit will avoid the use of the `$` global in the inline script execution context, and replace the functionality by listening for the `DOMContentLoaded` event instead.  The `$` global will continue to be used inside the event listener, since it will be available at that time.