### PR TITLE
Update project to use .NET 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the supporting code and deployment resources for the [C
 
 ## Prerequisites
 
-The sample is built on .NET 6, Razor, Bootstrap, and jQuery.
+The sample is built on .NET 7, Razor, Bootstrap, and jQuery.
 
 ## Setup
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.300",
+    "version": "7.0.400",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.401",
+    "version": "7.0.300",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "7.0.401",
     "rollForward": "latestMinor"
   }
 }

--- a/patient-records.csproj
+++ b/patient-records.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>patientrecords</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.4.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.11" />
   </ItemGroup>
 </Project>

--- a/patient-records.csproj
+++ b/patient-records.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.11" />
   </ItemGroup>
 </Project>

--- a/patient-records.csproj
+++ b/patient-records.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>patientrecords</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Updating project to use .NET 7 as older versions are no longer supported by training module sandbox environment.